### PR TITLE
Add boto3 in Dockerfile to support s3-like artifact access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Alexander Thamm GmbH <contact@alexanderthamm.com>"
 ARG MLFLOW_VERSION=1.19.0
 
 WORKDIR /mlflow/
-RUN pip install --no-cache-dir mlflow==$MLFLOW_VERSION
+RUN pip install --no-cache-dir mlflow==$MLFLOW_VERSION boto3
 EXPOSE 5000
 
 ENV BACKEND_URI sqlite:////mlflow/mlflow.db


### PR DESCRIPTION
Attempting to view artifacts stored on an s3-like object store results in an error "Loading Artifacts Failed..." because the `boto3` package is not installed.

This PR adds `boto3` to the `pip` command in the `Dockerfile` to add support for the server to access artifacts in s3-like object stores.