### PR TITLE
Added an argument for protobuf version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3-slim
+FROM python:3.10-slim
 LABEL maintainer="Alexander Thamm GmbH <contact@alexanderthamm.com>"
+ARG PROTOBUF_VERSION=3.19.0
 ARG MLFLOW_VERSION=1.19.0
 
 WORKDIR /mlflow/
-RUN pip install --no-cache-dir mlflow==$MLFLOW_VERSION
+RUN pip install --no-cache-dir protobuf==$PROTOBUF_VERSION mlflow==$MLFLOW_VERSION
 EXPOSE 5000
 
 ENV BACKEND_URI sqlite:////mlflow/mlflow.db


### PR DESCRIPTION
- Added an argument to freeze protobuf version in the `Dockerfile` because with default installation we face an error as mentioned [here](https://github.com/mlflow/mlflow/issues/5949)
- Version freeze for base docker image to avoid any error with future python release