### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ version: '3'
 services:
   mlflow:
     image: 'atcommons/mlflow-server'
-    build: .
     ports:
       - "5000:5000"
     volumes:


### PR DESCRIPTION
Docker-compose.yml has field 'build .' which should build Dockerfile. As docker-compose has an image that is used, build is not necessary.